### PR TITLE
fix: don't treat workflows that were intentionally skipped as failures

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -69,7 +69,7 @@ layout: base
             {% for workflow in repo.workflows | sortWorkflows %}
                 <li class="m-1">
                     <a href={{workflow[1][0].html_url}} target="_blank">
-                        <div class="text-sm p-1 rounded {{ "bg-green-300" if workflow[1][0].conclusion === "success" else "bg-red-400 " }}">{{workflow[0]}} <span class="text-xs block text-gray-600">{{workflow[1][0].created_at | daysAgo }}</span></div>
+                        <div class="text-sm p-1 rounded {{ "bg-red-400" if workflow[1][0].conclusion === "failure" else "bg-green-300" }}">{{workflow[0]}} <span class="text-xs block text-gray-600">{{workflow[1][0].created_at | daysAgo }}</span></div>
                     </a>
                 </li>
             {% endfor %}


### PR DESCRIPTION
A better workflow might involve setting different colors based on the possible statuses (neutral, success, skipped, cancelled, timed_out, action_required, failure) but that would likely require a custom filter to not become unwieldy, and I'm lazy. 😅