### PR TITLE
fix: correct provider version comparison

### DIFF
--- a/scripts/collect-status.js
+++ b/scripts/collect-status.js
@@ -9,6 +9,7 @@ const { retry } = require("@octokit/plugin-retry");
 const fs = require("fs").promises;
 const { createActionAuth } = require("@octokit/auth-action");
 const { createTokenAuth } = require("@octokit/auth-token");
+const semver = require("semver");
 
 async function processWorkflows(data) {
   const runSet = {};
@@ -235,7 +236,7 @@ async function getLatestProviderVersion(name, url) {
         published: data.attributes["published-at"],
       }))
       .sort((a, b) =>
-        a.published < b.published ? 1 : a.published > b.published ? -1 : 0
+        semver.lt(a.version, b.version) ? 1 : semver.gt(a.version, b.version) ? -1 : a.published < b.published ? 1 : a.published > b.published ? -1 : 0
       )[0].version;
 
     return providerVersion;


### PR DESCRIPTION
Trying to fix this issue which has been bothering me for some time:

![Screenshot 2024-09-16 at 16 01 25](https://github.com/user-attachments/assets/6b19d62f-acd7-429f-ba50-fa667830476e)

Basically: v5.44.0 was published more recently than v6.2.0, which is why this is being treated as an error; however, once we upgrade to supporting a new major version, we don't go back and publish additional patch or minor releases for the previous major version ourselves, so we do not care about any new version updates released for 5.x, we only care about 6.x. Therefore, having this be treated like an error on the dashboard is not helpful.