### PR TITLE
chore(deps): update pinned versions of GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,10 +90,10 @@ jobs:
       - name: Send failures to Slack
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
+          webhook: ${{ secrets.FAILURE_SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
           payload: |
             {
               "name": "cdktf-provider-dashboard",
               "run_url": "https://github.com/cdktf/cdktf-provider-dashboard/actions/runs/${{ github.run_id }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.FAILURE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
           name: build-artifact
           path: _site
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3         # TSCCR: could not find entry for peaceiris/actions-gh-pages
+        uses: peaceiris/actions-gh-pages@v3          # TSCCR: could not find entry for peaceiris/actions-gh-pages
         with:
           publish_dir: ./_site
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -88,7 +88,7 @@ jobs:
       contents: read
     steps:
       - name: Send failures to Slack
-        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           payload: |
             {


### PR DESCRIPTION
There are breaking changes in the v2 upgrade of the Slack integration -- see hashicorp/terraform-releases#149

TODO:
- [x] Address the breaking changes
- [x] Fix the webhook itself -- this one has been [broken for a while](https://github.com/cdktf/cdktf-provider-dashboard/actions/runs/12414849095/job/34660001037) ("webhook not found" error)